### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/Swissschoggi/Red/security/code-scanning/1](https://github.com/Swissschoggi/Red/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only checks out the repository and builds a Docker image, it does not require `write` permissions. The minimal permissions required are `contents: read`. This ensures the workflow has the least privileges necessary to complete its tasks.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. Alternatively, it can be added specifically to the `build` job if other jobs are added later that require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
